### PR TITLE
Close resources in JunrarFuzzer

### DIFF
--- a/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
+++ b/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
@@ -45,10 +45,8 @@ public class JunrarFuzzer {
         }
 
         public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-
-                try {
-                        InputStream inputStream = new ByteArrayInputStream(data.consumeRemainingAsBytes());
-                        Archive archive = new Archive(inputStream);
+                try (InputStream inputStream = new ByteArrayInputStream(data.consumeRemainingAsBytes());
+                     Archive archive = new Archive(inputStream)) {
 
                         try {
                                 SeekableReadOnlyByteChannel channel = archive.getChannel();
@@ -93,12 +91,11 @@ public class JunrarFuzzer {
                                                 }
                                         } catch (Throwable ignored) {}
                                 }
-                        } catch (RarException | IllegalArgumentException e) {
+                        } catch (RarException e) {
                                 return;
                         }
 
-                } catch (IOException e1) {
-                } catch (RarException e2) {
+                } catch (IOException | RarException ignored) {
                         return;
                 }
         }


### PR DESCRIPTION
## Summary
- close InputStream and Archive with try-with-resources in JunrarFuzzer to ensure resources are released
- remove unreachable exception catch for cleaner compilation

## Testing
- `python3 infra/helper.py check_build --sanitizer address junrar` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68b47fbc03ec8322b18bb23e3f851cf8