### PR TITLE
junrar: remove impossible RarException catch

### DIFF
--- a/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
+++ b/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
@@ -91,7 +91,7 @@ public class JunrarFuzzer {
                                                 }
                                         } catch (Throwable ignored) {}
                                 }
-                        } catch (RarException e) {
+                        } catch (RuntimeException e) {
                                 return;
                         }
 


### PR DESCRIPTION
## Summary
- fix JunrarFuzzer compilation error by catching RuntimeException instead of RarException

## Testing
- `python3 infra/presubmit.py lint -a` *(fails: duplicate-code)*
- `python3 infra/helper.py build_fuzzers junrar` *(fails: FileNotFoundError: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68b484c334c0832298ee2ca7b016da51