### PR TITLE
Fix Junrar fuzzer imports

### DIFF
--- a/projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java
+++ b/projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java
@@ -1,7 +1,7 @@
 package com.github.junrar.fuzz;
 
-import com.github.junrar.unpack.decode.FileNameDecoder;
-import com.code-intelligence.jazzer.api.FuzzedDataProvider;
+import com.github.junrar.rarfile.FileNameDecoder;
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 public class FileNameDecoderFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {


### PR DESCRIPTION
## Summary
- fix Jazzer import in Junrar FileNameDecoderFuzzer
- use proper FileNameDecoder package

## Testing
- `javac -cp /tmp/junrar-build/out/junrar.jar:/tmp/junrar-build/out/slf4j-api.jar:/tmp/junrar-build/out/slf4j-simple.jar:/tmp/junrar-build/out/jazzer_api_deploy.jar -d /tmp/junrar-build/out projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java`


------
https://chatgpt.com/codex/tasks/task_e_68b488994054832284e7b622d944ea61