### PR TITLE
Improve Junrar fuzzer coverage

### DIFF
--- a/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
+++ b/projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java
@@ -18,10 +18,10 @@ package com.github.junrar.fuzz;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import com.github.junrar.Archive;
 import com.github.junrar.exception.RarException;
@@ -31,72 +31,50 @@ import com.github.junrar.rarfile.MainHeader;
 import com.github.junrar.volume.Volume;
 
 public class JunrarFuzzer {
-        private static void touchHeader(FileHeader fh) {
-                if (fh == null) {
-                        return;
-                }
-                try { fh.isEncrypted(); } catch (Throwable ignored) {}
-                try { fh.isDirectory(); } catch (Throwable ignored) {}
-                try {
-                        fh.getFileName();
-                } catch (Throwable ignored) {
-                        try { fh.toString(); } catch (Throwable ignored2) {}
-                }
-        }
-
         public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-                try (InputStream inputStream = new ByteArrayInputStream(data.consumeRemainingAsBytes());
+                try (InputStream inputStream =
+                                new ByteArrayInputStream(data.consumeRemainingAsBytes());
                      Archive archive = new Archive(inputStream)) {
 
-                        try {
-                                SeekableReadOnlyByteChannel channel = archive.getChannel();
-                                if (channel != null) {
-                                        channel.getPosition();
-                                }
-                        } catch (Throwable ignored) {}
-
-                        try { archive.getFileHeaders(); } catch (Throwable ignored) {}
-                        try { archive.getHeaders(); } catch (Throwable ignored) {}
-
-                        try {
-                                MainHeader mh = archive.getMainHeader();
-                                if (mh != null) {
-                                        try { mh.getEncryptVersion(); } catch (Throwable ignored) {}
-                                        try { mh.isEncrypted(); } catch (Throwable ignored) {}
-                                }
-                        } catch (RuntimeException ignored) {}
-
-                        try {
-                                Volume vol = archive.getVolume();
-                                if (vol != null) {
-                                        try { vol.getChannel(); } catch (Throwable ignored) {}
-                                        try { vol.getLength(); } catch (Throwable ignored) {}
-                                }
-                        } catch (RuntimeException ignored) {}
-
-                        boolean archiveEncrypted = false;
-                        try { archiveEncrypted = archive.isEncrypted(); } catch (Throwable ignored) {}
-
-                        try {
-                                for (FileHeader fh : archive.getFileHeaders()) {
-                                        touchHeader(fh);
-                                        boolean headerEncrypted = false;
-                                        try { headerEncrypted = fh != null && fh.isEncrypted(); } catch (Throwable ignored) {}
-                                        if (archiveEncrypted || headerEncrypted) {
-                                                continue;
-                                        }
-                                        try {
-                                                if (fh != null && fh.getUnpSize() < (1 << 20)) {
-                                                        archive.extractFile(fh, OutputStream.nullOutputStream());
-                                                }
-                                        } catch (Throwable ignored) {}
-                                }
-                        } catch (RuntimeException e) {
-                                return;
+                        SeekableReadOnlyByteChannel channel = archive.getChannel();
+                        if (channel != null) {
+                                try { channel.getPosition(); } catch (Throwable ignored) {}
                         }
 
+                        // Exercise various accessors on Archive.
+                        try { archive.getFileHeaders(); } catch (Throwable ignored) {}
+                        try { archive.getHeaders(); } catch (Throwable ignored) {}
+                        try { archive.isOldFormat(); } catch (Throwable ignored) {}
+                        try { archive.isPasswordProtected(); } catch (Throwable ignored) {}
+
+                        MainHeader mh = archive.getMainHeader();
+                        if (mh != null) {
+                                try { mh.getEncryptVersion(); } catch (Throwable ignored) {}
+                                try { mh.isEncrypted(); } catch (Throwable ignored) {}
+                        }
+
+                        Volume vol = archive.getVolume();
+                        if (vol != null) {
+                                try { vol.getChannel(); } catch (Throwable ignored) {}
+                                try { vol.getLength(); } catch (Throwable ignored) {}
+                        }
+
+                        try { archive.isEncrypted(); } catch (Throwable ignored) {}
+
+                        FileHeader fh;
+                        while ((fh = archive.nextFileHeader()) != null) {
+                                try { fh.getCTime(); } catch (Throwable ignored) {}
+                                try { fh.isDirectory(); } catch (Throwable ignored) {}
+                                try { fh.hasVolumeNumber(); } catch (Throwable ignored) {}
+                                try { fh.isEncrypted(); } catch (Throwable ignored) {}
+                                try { fh.isSubBlock(); } catch (Throwable ignored) {}
+
+                                try {
+                                        archive.extractFile(fh, OutputStream.nullOutputStream());
+                                } catch (Throwable ignored) {}
+                        }
                 } catch (IOException | RarException ignored) {
-                        return;
+                        // Ignore exceptions from invalid archives.
                 }
         }
 }


### PR DESCRIPTION
## Summary
- refactor Junrar fuzzer to call additional archive accessors
- iterate over file headers extracting to null output stream without filename decoding

## Testing
- `javac -d /tmp/test_compile -cp /tmp/junrar_compile/junrar.jar:/tmp/junrar_compile/jazzer-api.jar:/tmp/junrar_compile/slf4j-api.jar:/tmp/junrar_compile/slf4j-simple.jar projects/junrar/com/github/junrar/fuzz/JunrarFuzzer.java`
- `ls /tmp/test_compile/com/github/junrar/fuzz`


------
https://chatgpt.com/codex/tasks/task_e_68b4946882a88322b020ad2f762aada4