### PR TITLE
junrar: improve FileNameDecoder fuzzer coverage

### DIFF
--- a/projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java
+++ b/projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java
@@ -3,13 +3,24 @@ package com.github.junrar.fuzz;
 import com.github.junrar.rarfile.FileNameDecoder;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
+/**
+ * Fuzzer for {@link FileNameDecoder}.
+ *
+ * <p>The decoder expects a starting position (encPos) within the input array. The previous
+ * implementation frequently provided offsets outside the array, leading to immediate exceptions and
+ * no meaningful coverage. This version ensures that the decoder is invoked with a range of valid
+ * offsets and tries multiple starting positions per fuzz input to exercise more of the decoding
+ * logic.</p>
+ */
 public class FileNameDecoderFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    byte[] nameBytes = data.consumeBytes(data.consumeInt(0, 256));
-    int encFlags = data.consumeInt(0, 0xFFFF);
-    try {
-      FileNameDecoder.decode(nameBytes, encFlags);
-    } catch (Throwable ignored) {
+    byte[] nameBytes = data.consumeBytes(data.consumeInt(1, 256));
+    int limit = Math.min(nameBytes.length, 64);
+    for (int encPos = 0; encPos < limit; encPos++) {
+      try {
+        FileNameDecoder.decode(nameBytes, encPos);
+      } catch (Throwable ignored) {
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- refine FileNameDecoder fuzzer to try multiple offsets within input
- add documentation about rationale

## Testing
- `javac projects/junrar/com/github/junrar/fuzz/FileNameDecoderFuzzer.java` *(fails: package com.github.junrar.rarfile does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b519e7de6c83229d24edafd6e25dfe