### PR TITLE
Add HeaderUtil fuzzer for zip4j

### DIFF
--- a/projects/zip4j/Dockerfile
+++ b/projects/zip4j/Dockerfile
@@ -35,5 +35,5 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
 RUN git clone --depth 1 https://github.com/srikanth-lingala/zip4j.git zip4j
 
 COPY build.sh $SRC/
-COPY Zip4jFuzzer.java $SRC/
+COPY *.java $SRC/
 WORKDIR $SRC/zip4j

--- a/projects/zip4j/HeaderUtilFuzzer.java
+++ b/projects/zip4j/HeaderUtilFuzzer.java
@@ -1,0 +1,66 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.ZipModel;
+import net.lingala.zip4j.headers.HeaderUtil;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HeaderUtilFuzzer {
+  public static void fuzzerInitialize() {
+    // Initializing objects for fuzzing
+  }
+
+  public static void fuzzerTearDown() {
+    // Tear down objects after fuzzing
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    List<String> names = new ArrayList<>();
+    List<Integer> variantCounts = new ArrayList<>();
+    int nameCount = data.consumeInt(1, 5);
+    for (int i = 0; i < nameCount; i++) {
+      names.add(data.consumeString(100));
+      variantCounts.add(data.consumeInt(1, 3));
+    }
+
+    try {
+      byte[] zipBytes = data.consumeRemainingAsBytes();
+      File tempFile = File.createTempFile("tempZip", ".zip");
+      try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+        fos.write(zipBytes);
+      }
+
+      ZipFile zipFile = new ZipFile(tempFile);
+      ZipModel zipModel = zipFile.getZipModel();
+
+      for (int i = 0; i < names.size(); i++) {
+        String baseName = names.get(i);
+        int loops = variantCounts.get(i);
+        for (int j = 0; j < loops; j++) {
+          String candidate = baseName + j;
+          for (int k = 0; k < 2; k++) {
+            String attempt = k == 0 ? candidate : candidate.toUpperCase();
+            try {
+              FileHeader header = HeaderUtil.getFileHeader(zipModel, attempt);
+              if (header != null) {
+                header.isDirectory();
+              }
+            } catch (ZipException e) {
+              // Expected for malformed inputs
+            }
+          }
+        }
+      }
+
+      tempFile.delete();
+    } catch (IOException e) {
+      // Ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add fuzzer for HeaderUtil.getFileHeader in zip4j
- ensure zip4j Docker image copies all fuzzers for build

## Testing
- `python3 infra/helper.py check_build --engine libfuzzer --sanitizer address zip4j` *(failed: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68b6706b0abc8322ac0ad60307b077b5