### PR TITLE
zip4j: adjust HeaderUtilFuzzer for API change

### DIFF
--- a/projects/zip4j/HeaderUtilFuzzer.java
+++ b/projects/zip4j/HeaderUtilFuzzer.java
@@ -1,7 +1,5 @@
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import net.lingala.zip4j.ZipFile;
-import net.lingala.zip4j.model.ZipModel;
-import net.lingala.zip4j.headers.HeaderUtil;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.FileHeader;
 
@@ -37,7 +35,6 @@ public class HeaderUtilFuzzer {
       }
 
       ZipFile zipFile = new ZipFile(tempFile);
-      ZipModel zipModel = zipFile.getZipModel();
 
       for (int i = 0; i < names.size(); i++) {
         String baseName = names.get(i);
@@ -47,7 +44,7 @@ public class HeaderUtilFuzzer {
           for (int k = 0; k < 2; k++) {
             String attempt = k == 0 ? candidate : candidate.toUpperCase();
             try {
-              FileHeader header = HeaderUtil.getFileHeader(zipModel, attempt);
+              FileHeader header = zipFile.getFileHeader(attempt);
               if (header != null) {
                 header.isDirectory();
               }


### PR DESCRIPTION
## Summary
- update HeaderUtilFuzzer to use ZipFile#getFileHeader instead of removed ZipFile#getZipModel

## Testing
- `javac -cp /tmp/zip4j-2.11.5.jar:/tmp/jazzer-api-0.24.0.jar /workspace/oss-fuzz-fork/projects/zip4j/HeaderUtilFuzzer.java`
- ❌ `python3 infra/helper.py check_build zip4j` (docker unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68b6f0e960548322b4377bc0b7bd9652