### PR TITLE
Handle ZipException in HeaderUtilFuzzer

### DIFF
--- a/projects/zip4j/HeaderUtilFuzzer.java
+++ b/projects/zip4j/HeaderUtilFuzzer.java
@@ -43,13 +43,14 @@ public class HeaderUtilFuzzer {
           String candidate = baseName + j;
           for (int k = 0; k < 2; k++) {
             String attempt = k == 0 ? candidate : candidate.toUpperCase();
+            FileHeader header;
             try {
-              FileHeader header = zipFile.getFileHeader(attempt);
-              if (header != null) {
-                header.isDirectory();
-              }
+              header = zipFile.getFileHeader(attempt);
             } catch (ZipException e) {
-              // Expected for malformed inputs
+              throw new RuntimeException(e);
+            }
+            if (header != null) {
+              header.isDirectory();
             }
           }
         }


### PR DESCRIPTION
## Summary
- Propagate ZipException instead of swallowing it when fetching file headers in HeaderUtilFuzzer
- Execute header logic only when a header is present

## Testing
- `javac projects/zip4j/HeaderUtilFuzzer.java` *(fails: package com.code_intelligence.jazzer.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b7013673e48322a5b4dcb2b784ba43