### PR TITLE
Propagate zip exceptions in zip4j header fuzzer

### DIFF
--- a/projects/zip4j/HeaderUtilFuzzer.java
+++ b/projects/zip4j/HeaderUtilFuzzer.java
@@ -43,21 +43,17 @@ public class HeaderUtilFuzzer {
           String candidate = baseName + j;
           for (int k = 0; k < 2; k++) {
             String attempt = k == 0 ? candidate : candidate.toUpperCase();
-            try {
-              FileHeader header = zipFile.getFileHeader(attempt);
-              if (header != null) {
-                header.isDirectory();
-              }
-            } catch (ZipException e) {
-              // Expected for malformed inputs
+            FileHeader header = zipFile.getFileHeader(attempt);
+            if (header != null) {
+              header.isDirectory();
             }
           }
         }
       }
 
       tempFile.delete();
-    } catch (IOException e) {
-      // Ignore
+    } catch (IOException | ZipException e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- simplify HeaderUtilFuzzer by removing internal try/catch
- rethrow ZipException and only call isDirectory when header is non-null

## Testing
- `python3 infra/presubmit.py lint` *(fails: multiple lint errors, aborted)*
- `javac projects/zip4j/HeaderUtilFuzzer.java` *(fails: package com.code_intelligence.jazzer.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b7013673e48322a5b4dcb2b784ba43