### PR TITLE
jsoup: include Introspector jar in build classpath

### DIFF
--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -30,6 +30,11 @@ ALL_JARS="jsoup.jar"
 # Jazzer API.
 BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
 
+if [[ -n ${FUZZ_INTROSPECTOR:-} ]]; then
+  fi_jar=$(find /fuzz-introspector -name 'fuzz-introspector-jvm-*.jar' -print -quit)
+  BUILD_CLASSPATH="$BUILD_CLASSPATH:$fi_jar"
+fi
+
 # All .jar and .class files lie in the same directory as the fuzzer at runtime.
 RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
 


### PR DESCRIPTION
## Summary
- detect Fuzz Introspector builds
- append Introspector JVM jar to build classpath

## Testing
- `python3 infra/helper.py lint jsoup` *(fails: invalid choice 'lint')*
- `python3 infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer jsoup` *(fails: No such file or directory: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68bcfbc9bb008322966892284e974c91