### PR TITLE
jsoup: add StreamParser fuzzer

### DIFF
--- a/projects/jsoup/Dockerfile
+++ b/projects/jsoup/Dockerfile
@@ -24,6 +24,7 @@ ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     mv fuzzing/dictionaries/html.dict $SRC/HtmlFuzzer.dict && \
+    cp $SRC/HtmlFuzzer.dict $SRC/StreamParserFuzzer.dict && \
     mv fuzzing/dictionaries/xml.dict $SRC/XmlFuzzer.dict && \
     rm -rf fuzzing
 
@@ -34,5 +35,5 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
 RUN git clone --depth 1 https://github.com/jhy/jsoup/
 
 COPY build.sh $SRC/
-COPY HtmlFuzzer.java XmlFuzzer.java $SRC/
+COPY HtmlFuzzer.java XmlFuzzer.java StreamParserFuzzer.java $SRC/
 WORKDIR $SRC/jsoup

--- a/projects/jsoup/StreamParserFuzzer.java
+++ b/projects/jsoup/StreamParserFuzzer.java
@@ -1,0 +1,28 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.StreamParser;
+
+public class StreamParserFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    Parser parser = Parser.htmlParser();
+    StreamParser sp = new StreamParser(parser);
+    sp.parse(data.consumeRemainingAsString(), "");
+  }
+}

--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -18,6 +18,9 @@
 # Move seed corpus and dictionary.
 mv $SRC/{*.zip,*.dict} $OUT
 
+# Remove central publishing plugin that pulls additional build extensions.
+sed -i '/<groupId>org.sonatype.central<\/groupId>/,/<\/plugin>/d' pom.xml
+
 MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
 $MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
 CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \


### PR DESCRIPTION
## Summary
- add minimal StreamParserFuzzer harness
- strip central publishing plugin during build

## Testing
- `bash projects/jsoup/build.sh` *(fails: mv: cannot stat '/*.zip': No such file or directory; sed: can't read pom.xml: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd025910a48322bbeb579932a4088b