### PR TITLE
jsoup: include Introspector jar in build classpath

### DIFF
--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -30,13 +30,18 @@ ALL_JARS="jsoup.jar"
 # Jazzer API.
 BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
 
+if [[ -n ${FUZZ_INTROSPECTOR:-} ]]; then
+  fi_jar=$(find /fuzz-introspector -name 'fuzz-introspector-jvm-*.jar' -print -quit)
+  BUILD_CLASSPATH="$BUILD_CLASSPATH:$fi_jar"
+fi
+
 # All .jar and .class files lie in the same directory as the fuzzer at runtime.
 RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
 
-for fuzzer in $(find $SRC -name '*Fuzzer.java'); do
-  fuzzer_basename=$(basename -s .java $fuzzer)
-  javac -cp $BUILD_CLASSPATH $fuzzer
-  cp $SRC/$fuzzer_basename.class $OUT/
+for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java "$fuzzer")
+  javac -cp $BUILD_CLASSPATH "$fuzzer"
+  cp "$(dirname "$fuzzer")/$fuzzer_basename.class" "$OUT/"
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/bash


### PR DESCRIPTION
## Summary
- detect Fuzz Introspector builds and add JVM jar to build classpath
- compile and copy fuzzers from their own directories

## Testing
- `python3 infra/helper.py lint jsoup` *(fails: invalid choice 'lint')*
- `python3 infra/helper.py build_fuzzers --sanitizer address --engine libfuzzer jsoup` *(fails: No such file or directory: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68bcfbc9bb008322966892284e974c91