### PR TITLE
jsoup: bypass Parser lock in XmlFuzzer

### DIFF
--- a/projects/jsoup/XmlFuzzer.java
+++ b/projects/jsoup/XmlFuzzer.java
@@ -16,11 +16,26 @@
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
-import org.jsoup.Jsoup;
-import org.jsoup.parser.Parser;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.jsoup.parser.XmlTreeBuilder;
 
 public class XmlFuzzer {
-  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    Jsoup.parse(data.consumeRemainingAsString(), "", Parser.xmlParser());
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) throws Exception {
+    String input = data.consumeRemainingAsString();
+    XmlTreeBuilder treeBuilder = new XmlTreeBuilder();
+
+    Method parse = XmlTreeBuilder.class.getDeclaredMethod("parse", String.class, String.class);
+    parse.setAccessible(true);
+    try {
+      parse.invoke(treeBuilder, input, "");
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      throw new RuntimeException(cause);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- call XmlTreeBuilder.parse via reflection to avoid Parser.parseInput locking

## Testing
- `python3 infra/helper.py build_fuzzers jsoup` *(fails: FileNotFoundError: No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68bf04e546688322969603f971d5fa87