### PR TITLE
Improve jsoup StreamParser fuzzer coverage

### DIFF
--- a/projects/jsoup/StreamParserFuzzer.java
+++ b/projects/jsoup/StreamParserFuzzer.java
@@ -23,6 +23,12 @@ public class StreamParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     Parser parser = Parser.htmlParser();
     StreamParser sp = new StreamParser(parser);
-    sp.parse(data.consumeRemainingAsString(), "");
+
+    boolean inAttribute = data.consumeBoolean();
+    String input = data.consumeRemainingAsString();
+
+    sp.parse(input, "");
+    // Exercise entity unescaping with guaranteed '&' to avoid early return.
+    Parser.unescapeEntities(input + "&", inAttribute);
   }
 }

--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -47,6 +47,8 @@ for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
   extra_args=""
   if [[ "$fuzzer_basename" == "XmlFuzzer" ]]; then
     extra_args="-focus_function=org.jsoup.parser.XmlTreeBuilder.*"
+  elif [[ "$fuzzer_basename" == "StreamParserFuzzer" ]]; then
+    extra_args="-focus_function=org.jsoup.parser.Parser.htmlParser"
   fi
   javac -cp $BUILD_CLASSPATH "$fuzzer"
   cp "$(dirname "$fuzzer")/$fuzzer_basename.class" "$OUT/"


### PR DESCRIPTION
## Summary
- exercise Parser.unescapeEntities to avoid early exit
- direct fuzzing focus to Parser.htmlParser

## Testing
- `python3 infra/helper.py build_fuzzers jsoup` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68bf1ea0749083228778fb0de716837d