### PR TITLE
Add tokenizer treebuilder fuzzer for jsoup

### DIFF
--- a/projects/jsoup/Dockerfile
+++ b/projects/jsoup/Dockerfile
@@ -35,5 +35,5 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
 RUN git clone --depth 1 https://github.com/jhy/jsoup/
 
 COPY build.sh $SRC/
-COPY HtmlFuzzer.java XmlFuzzer.java StreamParserFuzzer.java $SRC/
+COPY HtmlFuzzer.java XmlFuzzer.java StreamParserFuzzer.java FuzzTokenizerTreeBuilder.java $SRC/
 WORKDIR $SRC/jsoup

--- a/projects/jsoup/FuzzTokenizerTreeBuilder.java
+++ b/projects/jsoup/FuzzTokenizerTreeBuilder.java
@@ -1,0 +1,48 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.TagSet;
+
+public class FuzzTokenizerTreeBuilder {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsString();
+
+    Parser parser = Parser.htmlParser().newInstance();
+    parser.tagSet(TagSet.Html());
+
+    Document doc;
+    try {
+      doc = parser.parseInput(input, "");
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      return;
+    }
+
+    Element ctx = new Element("div");
+    try {
+      parser.parseFragmentInput(input, ctx, "");
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      // ignore expected errors
+    }
+
+    String html = doc.outerHtml();
+    Jsoup.parse(html);
+  }
+}

--- a/projects/jsoup/build.sh
+++ b/projects/jsoup/build.sh
@@ -42,7 +42,7 @@ fi
 # All .jar and .class files lie in the same directory as the fuzzer at runtime.
 RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
 
-for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
+for fuzzer in $(find "$SRC" -maxdepth 1 \( -name '*Fuzzer.java' -o -name 'FuzzTokenizerTreeBuilder.java' \)); do
   fuzzer_basename=$(basename -s .java "$fuzzer")
   extra_args=""
   if [[ "$fuzzer_basename" == "XmlFuzzer" ]]; then
@@ -71,3 +71,15 @@ fi
   \$@" > $OUT/$fuzzer_basename
   chmod u+x $OUT/$fuzzer_basename
 done
+
+# Create a basic seed corpus for FuzzTokenizerTreeBuilder if none is provided.
+mkdir -p $OUT/FuzzTokenizerTreeBuilder_seed_corpus
+cat <<'EOF' > $OUT/FuzzTokenizerTreeBuilder_seed_corpus/misnested.html
+<b><i></b></i>
+EOF
+cat <<'EOF' > $OUT/FuzzTokenizerTreeBuilder_seed_corpus/foreign.html
+<svg><script></script><circle></circle></svg>
+EOF
+cat <<'EOF' > $OUT/FuzzTokenizerTreeBuilder_seed_corpus/selfclosing.html
+<div />text
+EOF


### PR DESCRIPTION
## Summary
- add FuzzTokenizerTreeBuilder to exercise jsoup tokenizer and tree builder via public Parser API
- build and package the new target and seed corpus
- copy fuzzer source in Dockerfile

## Testing
- `javac projects/jsoup/FuzzTokenizerTreeBuilder.java` *(fails: package com.code_intelligence.jazzer.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c050a1764c832292477d3f5e1ebae4