### PR TITLE
Improve HTML fuzzer for jsoup

### DIFF
--- a/projects/jsoup/HtmlFuzzer.java
+++ b/projects/jsoup/HtmlFuzzer.java
@@ -17,9 +17,18 @@
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 
 import org.jsoup.Jsoup;
+import org.jsoup.parser.Parser;
 
 public class HtmlFuzzer {
+  private static final int MAX_INPUT_SIZE = 10000;
+
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    Jsoup.parse(data.consumeRemainingAsString());
+    boolean inAttribute = data.consumeBoolean();
+    String baseUri = data.consumeString(100);
+    String html = data.consumeString(MAX_INPUT_SIZE);
+
+    Jsoup.parse(html, baseUri);
+    Jsoup.parseBodyFragment(html, baseUri);
+    Parser.unescapeEntities(html, inAttribute);
   }
 }


### PR DESCRIPTION
## Summary
- expand jsoup HTML fuzzer to parse fragments and unescape entities
- bound fuzzer input size to avoid blocking loops

## Testing
- `python3 infra/helper.py check_build jsoup` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68c05b6b64dc8322bd26399db4856398