### PR TITLE
Improve StreamParser fuzzer

### DIFF
--- a/projects/jsoup/StreamParserFuzzer.java
+++ b/projects/jsoup/StreamParserFuzzer.java
@@ -22,13 +22,38 @@ import org.jsoup.parser.StreamParser;
 public class StreamParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     Parser parser = Parser.htmlParser();
+    // Enable additional parser features to increase code coverage.
+    parser.setTrackErrors(data.consumeInt(0, 100));
+    parser.setTrackPosition(data.consumeBoolean());
+
     StreamParser sp = new StreamParser(parser);
 
+    // Choose whether unescapeEntities should run in attribute mode.
     boolean inAttribute = data.consumeBoolean();
-    String input = data.consumeRemainingAsString();
 
-    sp.parse(input, "");
+    // Feed the input to the StreamParser in several chunks to exercise the
+    // streaming code paths and reduce locking contention.
+    StringBuilder allInput = new StringBuilder();
+    String baseUri = "";
+    int chunks = 1;
+    if (data.remainingBytes() > 0) {
+      chunks = data.consumeInt(1, Math.min(4, data.remainingBytes()));
+    }
+    for (int i = 0; i < chunks && data.remainingBytes() > 0; i++) {
+      int len = 0;
+      if (data.remainingBytes() > 0) {
+        len = data.consumeInt(0, data.remainingBytes());
+      }
+      String chunk = data.consumeString(len);
+      allInput.append(chunk);
+      sp.parse(chunk, baseUri);
+    }
+    String rest = data.consumeRemainingAsString();
+    allInput.append(rest);
+    sp.parse(rest, baseUri);
+    sp.finish();
+
     // Exercise entity unescaping with guaranteed '&' to avoid early return.
-    Parser.unescapeEntities(input + "&", inAttribute);
+    Parser.unescapeEntities(allInput.append('&').toString(), inAttribute);
   }
 }


### PR DESCRIPTION
## Summary
- enable error and position tracking for streamed parsing
- feed input in multiple chunks and finish to reduce locking and boost coverage

## Testing
- `./projects/jsoup/build.sh` *(fails: line 19: SRC: unbound variable)*

------
https://chatgpt.com/codex/tasks/task_e_68c05c6797fc83228d3a7f7b8b07dcef