### PR TITLE
refactor jsoup tokenizer fuzzer

### DIFF
--- a/projects/jsoup/FuzzTokenizerTreeBuilder.java
+++ b/projects/jsoup/FuzzTokenizerTreeBuilder.java
@@ -19,30 +19,27 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.parser.Parser;
-import org.jsoup.parser.TagSet;
 
 public class FuzzTokenizerTreeBuilder {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
 
-    Parser parser = Parser.htmlParser().newInstance();
-    parser.tagSet(TagSet.Html());
-
     Document doc;
     try {
-      doc = parser.parseInput(input, "");
+      doc = Jsoup.parse(input);
     } catch (IllegalArgumentException | IllegalStateException e) {
       return;
     }
 
     Element ctx = new Element("div");
     try {
-      parser.parseFragmentInput(input, ctx, "");
+      Parser.parseFragment(input, ctx, "");
     } catch (IllegalArgumentException | IllegalStateException e) {
       // ignore expected errors
     }
 
     String html = doc.outerHtml();
     Jsoup.parse(html);
+    Parser.parseBodyFragment(html, "");
   }
 }


### PR DESCRIPTION
## Summary
- streamline jsoup tokenizer fuzzer to avoid parser locking
- expand coverage by exercising fragment and body parsing paths

## Testing
- `javac projects/jsoup/FuzzTokenizerTreeBuilder.java` *(fails: package com.code_intelligence.jazzer.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c05eb4375483229c9d8850428a9239