### PR TITLE
Simplify HTML fuzzer for jsoup

### DIFF
--- a/projects/jsoup/HtmlFuzzer.java
+++ b/projects/jsoup/HtmlFuzzer.java
@@ -19,7 +19,14 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import org.jsoup.Jsoup;
 
 public class HtmlFuzzer {
+  private static final int MAX_INPUT_SIZE = 10_000;
+
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    Jsoup.parse(data.consumeRemainingAsString());
+    String html = data.consumeRemainingAsString();
+    if (html.length() > MAX_INPUT_SIZE) {
+      return;
+    }
+    Jsoup.parse(html);
+    Jsoup.parseBodyFragment(html);
   }
 }


### PR DESCRIPTION
## Summary
- consume all fuzz input as HTML and limit to 10k characters to avoid blocking loops
- parse documents and body fragments to reach more parser code paths

## Testing
- `python3 infra/helper.py check_build jsoup` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68c05b6b64dc8322bd26399db4856398