### PR TITLE
jsoup: fix duplicated method in XmlFuzzer

### DIFF
--- a/projects/jsoup/XmlFuzzer.java
+++ b/projects/jsoup/XmlFuzzer.java
@@ -24,8 +24,7 @@ import org.jsoup.parser.Parser;
  *
  * <p>The original fuzzer used reflection to bypass jsoup's internal locking
  * which in turn caused fuzz-introspector to report blocking operations and
- * limited the throughput.  This version relies only on the public API and
-
+ * limited the throughput. This version relies only on the public API and
  * bounds the size of the consumed input to keep parsing times short.</p>
  */
 public class XmlFuzzer {
@@ -34,9 +33,7 @@ public class XmlFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String xml = data.consumeString(MAX_INPUT_SIZE);
 
-
-  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    String input = data.consumeString(MAX_INPUT_SIZE);
+    Parser parser = Parser.xmlParser();
 
     try {
       parser.parseInput(xml, "");
@@ -48,7 +45,7 @@ public class XmlFuzzer {
       parser.parseFragmentInput(xml, new Element("root"), "");
     } catch (IllegalArgumentException | IllegalStateException ignored) {
       // Expected for malformed input.
-
     }
   }
 }
+


### PR DESCRIPTION
## Summary
- restore XmlFuzzer implementation

## Testing
- `python3 infra/presubmit.py -a lint` *(fails: Similar lines in 2 files)*
- `python3 infra/helper.py build_fuzzers jsoup` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68c06d2fe7b483229eb84330e120145b