### PR TITLE
Fix StreamParserFuzzer to use StreamParser.complete

### DIFF
--- a/projects/jsoup/StreamParserFuzzer.java
+++ b/projects/jsoup/StreamParserFuzzer.java
@@ -34,7 +34,10 @@ public class StreamParserFuzzer {
       int end = Math.min(i + chunkSize, input.length());
       sp.parse(input.substring(i, end), baseUri);
     }
-    sp.finish();
-
+    try {
+      sp.complete();
+    } catch (IOException ignored) {
+      // Ignore I/O errors during fuzzing.
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace removed `finish()` call with `complete()`
- ignore I/O errors during StreamParser completion

## Testing
- `python3 infra/presubmit.py format -a`
- `python3 infra/presubmit.py lint -a` *(fails: lint errors across repository)*
- `python3 infra/helper.py check_build jsoup` *(fails: FileNotFoundError: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68c06fae0324832297f37463db1e9aaa