### PR TITLE
jsoup: fix ResponseExecuteFuzzer data pair addition

### DIFF
--- a/projects/jsoup/ResponseExecuteFuzzer.java
+++ b/projects/jsoup/ResponseExecuteFuzzer.java
@@ -44,9 +44,7 @@ public class ResponseExecuteFuzzer {
       }
       int dataPairs = data.consumeInt(0, 3);
       for (int d = 0; d < dataPairs; d++) {
-        request
-            .data()
-            .add(Connection.KeyVal.create(data.consumeString(10), data.consumeString(20)));
+        request.data(data.consumeString(10), data.consumeString(20));
       }
 
       HttpConnection.Response previousResponse = null;


### PR DESCRIPTION
## Summary
- fix data pair addition in ResponseExecuteFuzzer to avoid missing KeyVal.create method

## Testing
- `python3 infra/presubmit.py lint` *(fails: Not a valid object name origin/HEAD)*

------
https://chatgpt.com/codex/tasks/task_e_68c086c71a0083229769239aea745d3f