### PR TITLE
jsoup: expand Response.execute fuzzer coverage

### DIFF
--- a/projects/jsoup/ResponseExecuteFuzzer.java
+++ b/projects/jsoup/ResponseExecuteFuzzer.java
@@ -11,11 +11,17 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
 import org.jsoup.Connection;
 import org.jsoup.helper.HttpConnection;
 
 public class ResponseExecuteFuzzer {
-  public static void fuzzerInitialize() {}
+  public static void fuzzerInitialize() {
+    // Use the classic UrlConnectionExecutor rather than the Java 11+ HttpClient
+    // implementation to ensure the custom FuzzHttpURLConnection is exercised.
+    System.setProperty("jsoup.useHttpClient", "false");
+  }
 
   public static void fuzzerTearDown() {}
 
@@ -23,19 +29,54 @@ public class ResponseExecuteFuzzer {
     // Generate a simple request and URL backed by a custom URLStreamHandler so that
     // HttpConnection.Response.execute does not perform a real network request.
     String path = data.consumeString(100);
+    int status = data.consumeInt(100, 599);
+    String contentType = data.pickValue(new String[] {
+        "text/html", "application/xml", "application/octet-stream", data.consumeString(20)});
+    String contentEncoding = data.pickValue(new String[] {"", "gzip", "deflate"});
+
+    boolean isRedirect = status >= 300 && status < 400;
+    String location = null;
     int headerCount = data.consumeInt(0, 3);
-    String[] headerKeys = new String[headerCount];
-    String[] headerVals = new String[headerCount];
-    for (int i = 0; i < headerCount; i++) {
-      headerKeys[i] = data.consumeString(20);
-      headerVals[i] = data.consumeString(50);
+    int extra = 1; // content-type
+    if (!contentEncoding.isEmpty()) extra++;
+    if (isRedirect) extra++;
+    String[] headerKeys = new String[headerCount + extra];
+    String[] headerVals = new String[headerCount + extra];
+    int h = 0;
+    headerKeys[h] = "Content-Type";
+    headerVals[h++] = contentType;
+    if (!contentEncoding.isEmpty()) {
+      headerKeys[h] = "Content-Encoding";
+      headerVals[h++] = contentEncoding;
     }
-    byte[] body = data.consumeRemainingAsBytes();
+    if (isRedirect) {
+      location = "http://example.com/" + data.consumeString(100);
+      headerKeys[h] = "Location";
+      headerVals[h++] = location;
+    }
+    for (int i = 0; i < headerCount; i++) {
+      headerKeys[h] = data.consumeString(20);
+      headerVals[h] = data.consumeString(50);
+      h++;
+    }
+
+    int bodyLen = Math.min(data.remainingBytes(), 4096);
+    byte[] body = data.consumeBytes(bodyLen);
+    byte[] encBody = body;
+    try {
+      if ("gzip".equalsIgnoreCase(contentEncoding)) {
+        encBody = gzip(body);
+      } else if ("deflate".equalsIgnoreCase(contentEncoding)) {
+        encBody = deflate(body);
+      }
+    } catch (IOException e) {
+      // ignore compression errors
+    }
 
     URL url;
     try {
       url = new URL(null, "http://example.com/" + path,
-          new FuzzURLStreamHandler(body, headerKeys, headerVals));
+          new FuzzURLStreamHandler(encBody, headerKeys, headerVals, status));
     } catch (MalformedURLException e) {
       return;
     }
@@ -43,14 +84,25 @@ public class ResponseExecuteFuzzer {
     HttpConnection.Request request = new HttpConnection.Request();
     request.url(url);
     request.method(data.pickValue(Connection.Method.values()));
+    request.ignoreHttpErrors(data.consumeBoolean());
+    request.ignoreContentType(data.consumeBoolean());
+    request.followRedirects(data.consumeBoolean());
+    request.maxBodySize(data.consumeInt(0, 1_000_000));
+    request.timeout(data.consumeInt(0, 5_000));
+    request.header("User-Agent", data.consumeString(40));
 
-    int runs = data.consumeInt(1, 3);
-    for (int i = 0; i < runs; i++) {
-      try {
-        HttpConnection.Response.execute(request, null);
-      } catch (IOException | IllegalArgumentException e) {
-        // ignore
+    try {
+      HttpConnection.Response res = HttpConnection.Response.execute(request, null);
+      if (data.consumeBoolean()) {
+        try {
+          res.parse();
+        } catch (IOException ignored) {
+        }
+      } else {
+        res.body();
       }
+    } catch (IOException | IllegalArgumentException e) {
+      // ignore
     }
   }
 
@@ -58,16 +110,18 @@ public class ResponseExecuteFuzzer {
     private final byte[] body;
     private final String[] headerKeys;
     private final String[] headerVals;
+    private final int responseCode;
 
-    FuzzURLStreamHandler(byte[] body, String[] headerKeys, String[] headerVals) {
+    FuzzURLStreamHandler(byte[] body, String[] headerKeys, String[] headerVals, int responseCode) {
       this.body = body;
       this.headerKeys = headerKeys;
       this.headerVals = headerVals;
+      this.responseCode = responseCode;
     }
 
     @Override
     protected URLConnection openConnection(URL u) {
-      return new FuzzHttpURLConnection(u, body, headerKeys, headerVals);
+      return new FuzzHttpURLConnection(u, body, headerKeys, headerVals, responseCode);
     }
   }
 
@@ -75,12 +129,15 @@ public class ResponseExecuteFuzzer {
     private final byte[] body;
     private final String[] headerKeys;
     private final String[] headerVals;
+    private final int responseCode;
 
-    protected FuzzHttpURLConnection(URL url, byte[] body, String[] headerKeys, String[] headerVals) {
+    protected FuzzHttpURLConnection(URL url, byte[] body, String[] headerKeys,
+        String[] headerVals, int responseCode) {
       super(url);
       this.body = body;
       this.headerKeys = headerKeys;
       this.headerVals = headerVals;
+      this.responseCode = responseCode;
     }
 
     @Override
@@ -100,18 +157,23 @@ public class ResponseExecuteFuzzer {
     }
 
     @Override
+    public InputStream getErrorStream() {
+      return new ByteArrayInputStream(body);
+    }
+
+    @Override
     public OutputStream getOutputStream() {
       return new ByteArrayOutputStream();
     }
 
     @Override
     public int getResponseCode() {
-      return 200;
+      return responseCode;
     }
 
     @Override
     public String getResponseMessage() {
-      return "OK";
+      return "";
     }
 
     @Override
@@ -144,5 +206,21 @@ public class ResponseExecuteFuzzer {
     public String getHeaderField(int n) {
       return n < headerVals.length ? headerVals[n] : null;
     }
+  }
+
+  private static byte[] gzip(byte[] input) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+      gz.write(input);
+    }
+    return out.toByteArray();
+  }
+
+  private static byte[] deflate(byte[] input) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (DeflaterOutputStream df = new DeflaterOutputStream(out)) {
+      df.write(input);
+    }
+    return out.toByteArray();
   }
 }


### PR DESCRIPTION
## Summary
- explore status codes, content-type/encoding combinations and redirects
- toggle request flags and invoke parsing/body to hit more branches
- set user agent via headers to avoid Request API mismatch
- disable HttpClient so custom FuzzHttpURLConnection is exercised
- bound fuzzed body size to avoid compression hotspots

## Testing
- `python3 infra/presubmit.py lint` *(fails: Not a valid object name origin/HEAD)*
- `python3 infra/helper.py build_fuzzers jsoup` *(fails: No such file or directory: 'docker')*
- `javac -cp /tmp/jsoup.jar:/tmp/jazzer-api.jar projects/jsoup/ResponseExecuteFuzzer.java`


------
https://chatgpt.com/codex/tasks/task_e_68c1a7cb07408322bc8aa28a2722d31e