### PR TITLE
jsoup: exercise parser error tracking

### DIFF
--- a/projects/jsoup/HtmlFuzzer.java
+++ b/projects/jsoup/HtmlFuzzer.java
@@ -21,6 +21,7 @@ import java.io.StringReader;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.parser.ParseSettings;
 import org.jsoup.parser.Parser;
 
 public class HtmlFuzzer {
@@ -31,8 +32,12 @@ public class HtmlFuzzer {
     String html = data.consumeString(MAX_INPUT_SIZE);
 
     Parser parser = Parser.htmlParser();
+    parser.setTrackErrors(data.consumeInt(0, 10));
+    parser.setTrackPosition(data.consumeBoolean());
+    parser.settings(new ParseSettings(data.consumeBoolean(), data.consumeBoolean()));
     Document doc = parser.parseInput(new StringReader(html), baseUri);
     parser.parseFragmentInput(new StringReader(html), new Element("ctx"), baseUri);
+    parser.getErrors();
 
     Jsoup.parse(html);
     Jsoup.parseBodyFragment(html);


### PR DESCRIPTION
## Summary
- randomly toggle parser error/position tracking and ParseSettings
- retrieve collected parse errors after parsing to exercise error list

## Testing
- `python3 infra/presubmit.py -a lint` *(fails: duplicate-code warnings, see tail)*
- `python3 infra/helper.py check_build jsoup` *(fails: FileNotFoundError: 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68c1d3b59b0083229f34c31aec1ef041