### PR TITLE
Add unescapeEntities fuzz coverage to jsoup

### DIFF
--- a/projects/jsoup/HtmlFuzzer.java
+++ b/projects/jsoup/HtmlFuzzer.java
@@ -36,6 +36,14 @@ public class HtmlFuzzer {
     parser.setTrackPosition(data.consumeBoolean());
     parser.settings(new ParseSettings(data.consumeBoolean(), data.consumeBoolean()));
     Document doc = parser.parseInput(new StringReader(html), baseUri);
+    if (!html.isEmpty()) {
+      int start = data.consumeInt(0, html.length());
+      int end = data.consumeInt(start, html.length());
+      String sub = html.substring(start, end);
+      boolean inAttr = data.consumeBoolean();
+      parser.unescapeEntities(sub, inAttr);
+      Parser.unescapeEntities(sub, inAttr);
+    }
     parser.parseFragmentInput(new StringReader(html), new Element("ctx"), baseUri);
     parser.getErrors();
 


### PR DESCRIPTION
## Summary
- exercise Parser#unescapeEntities using fuzzed substrings
- cover both instance and static parsing paths

## Testing
- `python infra/presubmit.py format` *(fails: Not a valid object name origin/HEAD)*
- `python infra/presubmit.py lint` *(fails: Not a valid object name origin/HEAD)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d6645bb883229e022e54c56e7bb8