### PR TITLE
Add jsoup2 project with HTML and XML fuzzers

### DIFF
--- a/projects/jsoup2/Dockerfile
+++ b/projects/jsoup2/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN curl -L https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.zip -o maven.zip && \
+    unzip maven.zip -d $SRC/maven && \
+    rm -rf maven.zip
+
+ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
+
+RUN git clone --depth 1 https://github.com/google/fuzzing && \
+    mv fuzzing/dictionaries/html.dict $SRC/HtmlFuzzer.dict && \
+    mv fuzzing/dictionaries/xml.dict $SRC/XmlFuzzer.dict && \
+    rm -rf fuzzing
+
+RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
+    zip -j $SRC/XmlFuzzer_seed_corpus.zip go-fuzz-corpus/xml/corpus/* && \
+    rm -rf go-fuzz-corpus
+
+RUN git clone --depth 1 https://github.com/jhy/jsoup/
+
+COPY build.sh $SRC/
+COPY HtmlFuzzer.java XmlFuzzer.java $SRC/
+WORKDIR $SRC/jsoup

--- a/projects/jsoup2/HtmlFuzzer.java
+++ b/projects/jsoup2/HtmlFuzzer.java
@@ -1,0 +1,96 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import java.io.StringReader;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.ParseSettings;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.Tag;
+import org.jsoup.parser.TagSet;
+
+public class HtmlFuzzer {
+  private static final int MAX_INPUT_SIZE = 10_000;
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String baseUri = data.consumeString(1000);
+    String html = data.consumeString(MAX_INPUT_SIZE);
+
+    Parser parser = Parser.htmlParser();
+    parser.setTrackErrors(data.consumeInt(0, 10));
+    parser.setTrackPosition(data.consumeBoolean());
+    parser.settings(new ParseSettings(data.consumeBoolean(), data.consumeBoolean()));
+
+    TagSet tagSet = TagSet.Html();
+    int ops = data.consumeInt(0, 100);
+    for (int i = 0; i < ops; i++) {
+      String tagName = data.consumeString(20);
+      if (tagName.isEmpty()) {
+        continue;
+      }
+      if (data.consumeBoolean()) {
+        tagSet.add(new Tag(tagName));
+      } else {
+        try {
+          Field field = TagSet.class.getDeclaredField("tags");
+          field.setAccessible(true);
+          Map<String, Map<String, Tag>> tags = (Map<String, Map<String, Tag>>) field.get(tagSet);
+          for (Map<String, Tag> nsTags : tags.values()) {
+            nsTags.remove(tagName);
+          }
+        } catch (ReflectiveOperationException ignored) {
+          // ignore
+        }
+      }
+    }
+    parser.tagSet(tagSet);
+    Document doc = parser.parseInput(new StringReader(html), baseUri);
+    if (!html.isEmpty()) {
+      int start = data.consumeInt(0, html.length());
+      int end = data.consumeInt(start, html.length());
+      String sub = html.substring(start, end);
+      boolean inAttr = data.consumeBoolean();
+      parser.unescapeEntities(sub, inAttr);
+      Parser.unescapeEntities(sub, inAttr);
+    }
+    parser.parseFragmentInput(new StringReader(html), new Element("ctx"), baseUri);
+    parser.getErrors();
+
+    Jsoup.parse(html);
+    Jsoup.parseBodyFragment(html);
+
+    for (Element element : doc.getAllElements()) {
+      switch (Math.floorMod(data.consumeInt(), 3)) {
+
+        case 0:
+          element.tagName();
+          break;
+        case 1:
+          element.tag().prefix();
+          break;
+        default:
+          element.tag().set(data.consumeInt());
+          break;
+      }
+    }
+  }
+}

--- a/projects/jsoup2/XmlFuzzer.java
+++ b/projects/jsoup2/XmlFuzzer.java
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+
+/**
+ * Fuzzer for exercising the jsoup XML parser.
+ *
+ * <p>The original fuzzer used reflection to bypass jsoup's internal locking
+ * which in turn caused fuzz-introspector to report blocking operations and
+ * limited the throughput. This version relies only on the public API and
+ * bounds the size of the consumed input to keep parsing times short.</p>
+ */
+public class XmlFuzzer {
+  private static final int MAX_INPUT_SIZE = 4_096; // avoid pathological inputs
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String xml = data.consumeString(MAX_INPUT_SIZE);
+
+    Parser parser = Parser.xmlParser();
+
+    try {
+      parser.parseInput(xml, "");
+    } catch (IllegalArgumentException | IllegalStateException ignored) {
+      // Expected for malformed input.
+    }
+
+    try {
+      parser.parseFragmentInput(xml, new Element("root"), "");
+    } catch (IllegalArgumentException | IllegalStateException ignored) {
+      // Expected for malformed input.
+    }
+  }
+}
+

--- a/projects/jsoup2/build.sh
+++ b/projects/jsoup2/build.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -eu
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+# Move seed corpus and dictionary.
+mv $SRC/{*.zip,*.dict} $OUT
+
+# Remove central publishing plugin that pulls additional build extensions.
+
+perl -0 -i -pe 's|<plugin>\s*<groupId>org\.sonatype\.central</groupId>.*?</plugin>||s' pom.xml
+
+MAVEN_ARGS="-Dmaven.test.skip=true -Djavac.src.version=15 -Djavac.target.version=15"
+$MVN package org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade $MAVEN_ARGS
+CURRENT_VERSION=$($MVN org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
+ -Dexpression=project.version -q -DforceStdout)
+cp "target/jsoup-$CURRENT_VERSION.jar" $OUT/jsoup.jar
+
+ALL_JARS="jsoup.jar"
+
+# The classpath at build-time includes the project jars in $OUT as well as the
+# Jazzer API.
+BUILD_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "$OUT/%s:"):$JAZZER_API_PATH
+
+if [[ -n ${FUZZ_INTROSPECTOR:-} ]]; then
+  fi_jar=$(find /fuzz-introspector -name 'fuzz-introspector-jvm-*.jar' -print -quit)
+  BUILD_CLASSPATH="$BUILD_CLASSPATH:$fi_jar"
+fi
+
+# All .jar and .class files lie in the same directory as the fuzzer at runtime.
+RUNTIME_CLASSPATH=$(echo $ALL_JARS | xargs printf -- "\$this_dir/%s:"):\$this_dir
+
+for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
+  fuzzer_basename=$(basename -s .java "$fuzzer")
+  extra_args=""
+  if [[ "$fuzzer_basename" == "XmlFuzzer" ]]; then
+    extra_args="-focus_function=org.jsoup.parser.XmlTreeBuilder.*"
+  fi
+  javac -cp $BUILD_CLASSPATH -d $OUT "$fuzzer"
+  package_name=$(grep -E '^package ' "$fuzzer" | sed 's/package \(.*\);/\1/')
+  if [[ -n "$package_name" ]]; then
+    target_class="$package_name.$fuzzer_basename"
+  else
+    target_class="$fuzzer_basename"
+  fi
+
+  # Create an execution wrapper that executes Jazzer with the correct arguments.
+  echo "#!/bin/bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname \"\$0\")
+if [[ \"\$@\" =~ (^| )-runs=[0-9]+($| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
+  LD_LIBRARY_PATH=\"$JVM_LD_LIBRARY_PATH\":\$this_dir \
+  \$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \
+  --cp=$RUNTIME_CLASSPATH \
+  --target_class=$target_class \
+  --jvm_args=\"\$mem_settings\" \
+  $extra_args \
+  \$@" > $OUT/$fuzzer_basename
+  chmod u+x $OUT/$fuzzer_basename
+done
+

--- a/projects/jsoup2/project.yaml
+++ b/projects/jsoup2/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://github.com/jhy/jsoup/"
+language: jvm
+primary_contact: "jonathan@hedley.net"
+fuzzing_engines:
+  - libfuzzer
+main_repo: "https://github.com/jhy/jsoup/"
+sanitizers:
+  - address
+auto_ccs:
+  - "ffrr33aakk@gmail.com"
+vendor_ccs:
+  - "wagner@code-intelligence.com"
+  - "hlin@code-intelligence.com"
+  - "bug-disclosure@code-intelligence.com"


### PR DESCRIPTION
## Summary
- add jsoup2 project copied from jsoup but retaining only HtmlFuzzer and XmlFuzzer
- update build script and Dockerfile to handle the reduced fuzzer set

## Testing
- `python3 infra/helper.py build_fuzzers jsoup2` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68c243deec288322b99b649690d4a9f0