### PR TITLE
jsoup2: add ParseFuzzer

### DIFF
--- a/projects/jsoup2/Dockerfile
+++ b/projects/jsoup2/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
 RUN git clone --depth 1 https://github.com/jhy/jsoup/
 
 COPY build.sh $SRC/
-COPY HtmlFuzzer.java XmlFuzzer.java DataUtilFuzzer.java $SRC/
+COPY HtmlFuzzer.java XmlFuzzer.java DataUtilFuzzer.java ParseFuzzer.java $SRC/
 COPY seeds/datautil_corpus $SRC/datautil_corpus
 COPY dicts/encodings.dict $SRC/encodings.dict
 

--- a/projects/jsoup2/ParseFuzzer.java
+++ b/projects/jsoup2/ParseFuzzer.java
@@ -1,0 +1,53 @@
+package org.jsoup.fuzz;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.helper.W3CDom;
+import org.jsoup.helper.DataUtil;
+import org.jsoup.helper.UrlBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class ParseFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    try {
+      // Raw string input
+      String html = data.consumeRemainingAsString();
+
+      // 1. Standard HTML parsing
+      Document doc = Jsoup.parse(html);
+
+      // 2. Fragment parsing (different tree-builder path)
+      Jsoup.parseBodyFragment(html);
+
+      // 3. Encoding-sensitive path (DataUtil)
+      byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
+      DataUtil.load(
+          new ByteArrayInputStream(bytes),
+          "UTF-8", // charset
+          null // base URI
+      );
+
+      // 4. URL handling path (UrlBuilder)
+      try {
+        String base = "http://example.com/";
+        URL url = new URL(base + html.replaceAll("[^a-zA-Z0-9]", ""));
+        new UrlBuilder(url).build();
+      } catch (Exception ignored) {}
+
+      // 5. W3C DOM conversion (deeper tree traversal)
+      W3CDom w3c = new W3CDom();
+      w3c.fromJsoup(doc);
+
+    } catch (IllegalArgumentException | IOException ignored) {
+      // Expected on malformed input
+    } catch (Throwable t) {
+      // Crash of interest
+      throw t;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ParseFuzzer covering jsoup parse paths, DataUtil, URL handling, and W3C DOM conversion
- update Dockerfile to include new fuzzer source

## Testing
- `python3 infra/lint_fuzz_targets.py projects/jsoup2` *(fails: No such file or directory)*
- `python3 infra/presubmit.py lint` *(fails: Not a valid object name origin/HEAD)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e2be60e083228937e16921aadb7a