### PR TITLE
jsoup2: reuse parser instance in xml fuzzer

### DIFF
--- a/projects/jsoup2/XmlFuzzer.java
+++ b/projects/jsoup2/XmlFuzzer.java
@@ -29,23 +29,24 @@ import org.jsoup.parser.Parser;
  */
 public class XmlFuzzer {
   private static final int MAX_INPUT_SIZE = 4_096; // avoid pathological inputs
+  private static final Parser PARSER_TEMPLATE = Parser.xmlParser();
+  private static final Element ROOT = new Element("root");
 
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String xml = data.consumeString(MAX_INPUT_SIZE);
 
-    Parser parser = Parser.xmlParser();
-
+    Parser parser = PARSER_TEMPLATE.newInstance();
     try {
       parser.parseInput(xml, "");
     } catch (IllegalArgumentException | IllegalStateException ignored) {
       // Expected for malformed input.
     }
 
+    parser = PARSER_TEMPLATE.newInstance();
     try {
-      parser.parseFragmentInput(xml, new Element("root"), "");
+      parser.parseFragmentInput(xml, ROOT, "");
     } catch (IllegalArgumentException | IllegalStateException ignored) {
       // Expected for malformed input.
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- avoid repeated calls to Parser.xmlParser by reusing a parser template
- parse fragments and full documents with fresh Parser copies for greater coverage

## Testing
- `python3 infra/presubmit.py lint` *(fails: Not a valid object name origin/HEAD)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f1f536c083229fc6c6c434e5c546