### PR TITLE
jsoup2: update fuzzers and integrate XmlFuzzer

### DIFF
--- a/projects/jsoup2/DataUtilFuzzer.java
+++ b/projects/jsoup2/DataUtilFuzzer.java
@@ -7,6 +7,12 @@ import java.io.InputStream;
 import org.jsoup.helper.DataUtil;
 import org.jsoup.nodes.Document;
 
+// Dictionary
+// Use this with the libFuzzer -dict=DICT.file flag
+//
+// Fuzzer function priority
+// Use one of these functions as input to libFuzzer with flag -focus_function name
+// -focus_function=org.jsoup.internal.StringUtil.borrowBuilder
 public class DataUtilFuzzer {
     private static final String[] CHARSETS = {
         "UTF-8", "UTF-16", "UTF-16LE", "UTF-16BE", "UTF-32",

--- a/projects/jsoup2/Dockerfile
+++ b/projects/jsoup2/Dockerfile
@@ -24,12 +24,13 @@ ENV MVN $SRC/maven/apache-maven-3.6.3/bin/mvn
 
 RUN git clone --depth 1 https://github.com/google/fuzzing && \
     cp fuzzing/dictionaries/html.dict $SRC/HtmlFuzzer.dict && \
-    cp fuzzing/dictionaries/html.dict $SRC/OGHtmlFuzzer.dict && \
+    cp fuzzing/dictionaries/xml.dict $SRC/XmlFuzzer.dict && \
     cp fuzzing/dictionaries/xml.dict $SRC/OGXmlFuzzer.dict && \
     rm -rf fuzzing
 
 RUN git clone --depth 1 https://github.com/dvyukov/go-fuzz-corpus && \
     zip -j $SRC/OGXmlFuzzer_seed_corpus.zip go-fuzz-corpus/xml/corpus/* && \
+    zip -j $SRC/XmlFuzzer_seed_corpus.zip go-fuzz-corpus/xml/corpus/* && \
     rm -rf go-fuzz-corpus
 
 RUN git clone --depth 1 https://github.com/jhy/jsoup/
@@ -37,7 +38,7 @@ RUN git clone --depth 1 https://github.com/jhy/jsoup/
 COPY build.sh $SRC/
 
 
-COPY HtmlFuzzer.java DataUtilFuzzer.java ParseFuzzer.java OGHtmlFuzzer.java OGXmlFuzzer.java $SRC/
+COPY HtmlFuzzer.java DataUtilFuzzer.java ParseFuzzer.java OGXmlFuzzer.java XmlFuzzer.java $SRC/
 COPY seeds/datautil_corpus $SRC/datautil_corpus
 COPY dicts/encodings.dict $SRC/encodings.dict
 

--- a/projects/jsoup2/OGHtmlFuzzer.java
+++ b/projects/jsoup2/OGHtmlFuzzer.java
@@ -1,9 +1,0 @@
-import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-
-import org.jsoup.Jsoup;
-
-public class OGHtmlFuzzer {
-  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
-    Jsoup.parse(data.consumeRemainingAsString());
-  }
-}

--- a/projects/jsoup2/XmlFuzzer.java
+++ b/projects/jsoup2/XmlFuzzer.java
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+
+/**
+ * Fuzzer for exercising the jsoup XML parser.
+ *
+ * <p>The original fuzzer used reflection to bypass jsoup's internal locking
+ * which in turn caused fuzz-introspector to report blocking operations and
+ * limited the throughput. This version relies only on the public API and
+ * bounds the size of the consumed input to keep parsing times short.</p>
+ */
+public class XmlFuzzer {
+  private static final int MAX_INPUT_SIZE = 4_096; // avoid pathological inputs
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String xml = data.consumeString(MAX_INPUT_SIZE);
+
+    Parser parser = Parser.xmlParser();
+
+    try {
+      parser.parseInput(xml, "");
+    } catch (IllegalArgumentException | IllegalStateException ignored) {
+      // Expected for malformed input.
+    }
+
+    try {
+      parser.parseFragmentInput(xml, new Element("root"), "");
+    } catch (IllegalArgumentException | IllegalStateException ignored) {
+      // Expected for malformed input.
+    }
+  }
+}
+

--- a/projects/jsoup2/build.sh
+++ b/projects/jsoup2/build.sh
@@ -58,10 +58,10 @@ for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
   fuzzer_basename=$(basename -s .java "$fuzzer")
   extra_args=""
   wrapper_name="$fuzzer_basename"
-  if [[ "$fuzzer_basename" == "OGXmlFuzzer" ]]; then
-    extra_args="-focus_function=org.jsoup.parser.XmlTreeBuilder.*"
-  fi
-  javac -cp $BUILD_CLASSPATH -d $OUT "$fuzzer"
+    if [[ "$fuzzer_basename" == "OGXmlFuzzer" ]]; then
+      extra_args="-focus_function=org.jsoup.parser.XmlTreeBuilder.*"
+    fi
+    javac -cp $BUILD_CLASSPATH -d $OUT "$fuzzer"
   package_name=$(grep -E '^package ' "$fuzzer" | sed 's/package \(.*\);/\1/')
   if [[ -n "$package_name" ]]; then
     target_class="$package_name.$fuzzer_basename"
@@ -71,11 +71,12 @@ for fuzzer in $(find "$SRC" -maxdepth 1 -name '*Fuzzer.java'); do
 
   target_class_flag=$target_class
   extra_env=""
-  if [[ "$fuzzer_basename" == "DataUtilFuzzer" ]]; then
-    wrapper_name="datautil_fuzzer"
-    extra_env="export FUZZ_TARGET_CLASS=$target_class"
-    target_class_flag="\$FUZZ_TARGET_CLASS"
-  fi
+    if [[ "$fuzzer_basename" == "DataUtilFuzzer" ]]; then
+      wrapper_name="datautil_fuzzer"
+      extra_env="export FUZZ_TARGET_CLASS=$target_class"
+      target_class_flag="\$FUZZ_TARGET_CLASS"
+      extra_args="-dict=\$this_dir/${wrapper_name}.dict -focus_function=org.jsoup.internal.StringUtil.borrowBuilder"
+    fi
 
   # Create an execution wrapper that executes Jazzer with the correct arguments.
   echo "#!/bin/bash


### PR DESCRIPTION
## Summary
- remove OGHtmlFuzzer and associated Docker build steps
- add XmlFuzzer and hook it into build and Dockerfile
- document DataUtilFuzzer dictionary & focus function and pass corresponding flags

## Testing
- `python3 infra/helper.py check_build jsoup2` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*
- `python3 infra/presubmit.py lint` *(fails: Command '['git', 'merge-base', 'HEAD', 'origin/HEAD']' returned non-zero exit status 128)*

------
https://chatgpt.com/codex/tasks/task_e_68c31505ac7c8322b1966f9e890ad174