### PR TITLE
pdfbox: fix PDFStreamParser fuzzer constructor usage

### DIFF
--- a/projects/pdfbox/project-parent/fuzz-targets/src/test/java/com/example/PDFStreamParserFuzzer.java
+++ b/projects/pdfbox/project-parent/fuzz-targets/src/test/java/com/example/PDFStreamParserFuzzer.java
@@ -1,14 +1,15 @@
 package com.example;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import org.apache.pdfbox.contentstream.PDContentStream;
 import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdfparser.PDFStreamParser;
 
-import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.util.List;
 
 public class PDFStreamParserFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) throws Exception {
@@ -21,16 +22,17 @@ public class PDFStreamParserFuzzer {
       doc.addPage(page);
 
       COSStream cosStream = new COSStream();
-      cosStream.setItem("Length", new COSArray()); // provoke edge cases around Length handling
-      cosStream.setFilters(new COSArray());        // empty filters array
-      cosStream.createOutputStream().write(streamBytes);
+      cosStream.setItem(COSName.LENGTH, new COSArray()); // provoke edge cases around Length handling
+      cosStream.setItem(COSName.FILTER, new COSArray()); // empty filters array
+      try (OutputStream output = cosStream.createOutputStream()) {
+        output.write(streamBytes);
+      }
 
-      PDContentStream cs = new PDContentStream(page);
-      PDFStreamParser parser = new PDFStreamParser(new ByteArrayInputStream(streamBytes));
-      parser.parse(); // exercises inline images, operators, operands
-      // Touch the tokens list to force object creation paths.
-      if (parser.getTokens() != null && !parser.getTokens().isEmpty()) {
-        parser.getTokens().get(0);
+      PDFStreamParser parser = new PDFStreamParser(cosStream);
+      parser.parse();
+      List<Object> tokens = parser.getTokens(); // exercises inline images, operators, operands
+      if (!tokens.isEmpty()) {
+        tokens.get(0); // force object creation paths
       }
     }
   }


### PR DESCRIPTION
## Summary
- use a COSStream-backed parser to match the available PDFStreamParser constructors
- close the COS stream output and reuse getTokens() after parsing for token access
- rely on COSName constants for crafted metadata keys

## Testing
- `mvn -f projects/pdfbox/project-parent/fuzz-targets/pom.xml -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c838163f9883229971f16dd864cd91